### PR TITLE
Added support for oauth2 service

### DIFF
--- a/lib/pollers/oauthHttps/httpsPoller.js
+++ b/lib/pollers/oauthHttps/httpsPoller.js
@@ -8,6 +8,7 @@ var http  = require('http');
 var url   = require('url');
 var fs    = require('fs');
 var ejs   = require('ejs');
+var qs    = require('querystring');
 var BaseHttpPoller = require('../http/baseHttpPoller');
 
 // The http module lacks proxy support. Let's monkey-patch it.
@@ -33,7 +34,7 @@ HttpsPoller.validateTarget = function(target) {
   return url.parse(target).protocol == 'https:';
 };
 
-getAccessToken = function(self, oauthEndpoint, credentials, onSuccess, onError) {
+getAccessToken = function(self, oauthEndpoint, params, credentials, onSuccess, onError) {
   try {
     var req = https.request(oauthEndpoint, function(res) {
       res.setEncoding('utf8');
@@ -46,7 +47,8 @@ getAccessToken = function(self, oauthEndpoint, credentials, onSuccess, onError) 
 
         res.on('end', function () {
           try {
-            onSuccess(self, JSON.parse(body).accessToken);
+            var parsed_body = JSON.parse(body);
+            onSuccess(self, parsed_body.accessToken || parsed_body.access_token);
           } catch(err) {
             onError(self, {name: "InvalidResponseData", message: "oauth authentication failed, invalid data in response"});
           }
@@ -59,7 +61,12 @@ getAccessToken = function(self, oauthEndpoint, credentials, onSuccess, onError) 
     req.on('error', function (err) {
       onError(self, err);
     });
-    req.end(JSON.stringify(credentials), "utf-8");
+    if (typeof params != 'undefined') {
+      req.write(qs.stringify(params), "utf-8");
+    } else if (typeof credentials != 'undefined') {
+      req.write(JSON.stringify(credentials), "utf-8");
+    }
+    req.end();
   } catch(err) {
     onError(self, {name: "UnknownError", message: "oauth authentication failed, an unknown error occured ("+err.message+")"}); 
   }
@@ -71,7 +78,7 @@ getAccessToken = function(self, oauthEndpoint, credentials, onSuccess, onError) 
  * @api   public
  */
 HttpsPoller.prototype.poll = function(secure) {
-  getAccessToken(this, this.target.endpoint, this.target.credentials, function(self, token) { 
+  getAccessToken(this, this.target.endpoint, this.target.params, this.target.credentials, function(self, token) {
     HttpsPoller.super_.prototype.poll.call(self);
     secure = typeof secure !== 'undefined' ? secure : true;
     try {


### PR DESCRIPTION
We talked yesterday about Uptime https+oauth plugin and using it with oauth2 /token endpoint. I’ve prepared a pull request which extends the plugin with such capability (preserving its current functionality).
