### PR TITLE
Change of access token regex format

### DIFF
--- a/lib/pollers/oauthHttps/httpsPoller.js
+++ b/lib/pollers/oauthHttps/httpsPoller.js
@@ -53,7 +53,7 @@ getAccessToken = function (self, oauthEndpoint, params, credentials, onSuccess, 
                     try {
                         var token;
                         if (typeof credentials != 'undefined' && credentials.response_type === 'token'){
-                            token = res.headers.location.match(/(?:access_token=)([A-Za-z0-9]+)/)[1];
+                            token = res.headers.location.match(/(?:access_token=)([A-Za-z0-9-]+)/)[1];
                         }
                         else {
                             var jsonBody = JSON.parse(body);


### PR DESCRIPTION
We've just switched to a new access token format which contain hyphens ( '-' ).
Because of that parsing done in this file does not work any longer, we need to add hyphen as a valid character.
Please accept it ASAP, since right now we're working in "emergency" mode ;)